### PR TITLE
95 functionality add leak obstacle

### DIFF
--- a/Scenes/boat.gd
+++ b/Scenes/boat.gd
@@ -39,3 +39,17 @@ func _generate_boat():
 func change_speed(change: int):
 	speed += change
 	Globals.update_boat_speed(speed)
+
+func spawn_leak():
+	$DeckSlot.get_children().front().spawn_leak()
+
+func spawn_puddle(spawn_point: Vector2):
+	return $DeckSlot.get_children().front().spawn_puddle(spawn_point)
+	
+func add_obstacle(new_obstacle: Node2D):
+	if new_obstacle is Puddle:
+		$Obstacles/Puddles.add_child(new_obstacle)
+	elif new_obstacle is Leak:
+		$Obstacles/Leaks.add_child(new_obstacle)
+	else:
+		$Obstacles.add_child(new_obstacle)

--- a/Scenes/boat.gd
+++ b/Scenes/boat.gd
@@ -65,7 +65,6 @@ func is_point_in_boat(point: Vector2):
 	if bow.is_point_in_play_space(point) or stern.is_point_in_play_space(point):
 		return true
 	
-	# Check if point already overlaps with a puddle
 	for deck in decks:
 		if deck.is_point_in_play_space(point):
 			return true

--- a/Scenes/boat.gd
+++ b/Scenes/boat.gd
@@ -44,7 +44,10 @@ func spawn_leak():
 	$DeckSlot.get_children().front().spawn_leak()
 
 func spawn_puddle(spawn_point: Vector2):
-	return $DeckSlot.get_children().front().spawn_puddle(spawn_point)
+	if is_point_in_boat(spawn_point):
+		return $DeckSlot.get_children().front().spawn_puddle(spawn_point)
+	
+	return null
 	
 func add_obstacle(new_obstacle: Node2D):
 	if new_obstacle is Puddle:
@@ -53,3 +56,18 @@ func add_obstacle(new_obstacle: Node2D):
 		$Obstacles/Leaks.add_child(new_obstacle)
 	else:
 		$Obstacles.add_child(new_obstacle)
+		
+func is_point_in_boat(point: Vector2):
+	var bow = $BowSlot/Bow
+	var stern = $SternSlot/Stern
+	var decks = $DeckSlot.get_children()
+	
+	if bow.is_point_in_play_space(point) or stern.is_point_in_play_space(point):
+		return true
+	
+	# Check if point already overlaps with a puddle
+	for deck in decks:
+		if deck.is_point_in_play_space(point):
+			return true
+	
+	return false

--- a/Scenes/boat.tscn
+++ b/Scenes/boat.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=5 format=3 uid="uid://ptto4146phwg"]
 
-[ext_resource type="PackedScene" uid="uid://c0wkpqqx3mqf0" path="res://Scenes/bow.tscn" id="1_17osx"]
+[ext_resource type="PackedScene" uid="uid://bg0meusunoosr" path="res://Scenes/bow.tscn" id="1_17osx"]
 [ext_resource type="Script" path="res://Scenes/boat.gd" id="1_c5j0p"]
 [ext_resource type="PackedScene" uid="uid://ccika7v5l27ew" path="res://Scenes/deck.tscn" id="2_kxpgr"]
-[ext_resource type="PackedScene" uid="uid://rdtpfywwpj45" path="res://Scenes/stern.tscn" id="3_701t0"]
+[ext_resource type="PackedScene" uid="uid://dmy5awjreptlw" path="res://Scenes/stern.tscn" id="3_701t0"]
 
 [node name="Boat" type="Node2D"]
 script = ExtResource("1_c5j0p")

--- a/Scenes/boat.tscn
+++ b/Scenes/boat.tscn
@@ -24,3 +24,9 @@ position = Vector2(0, -120)
 position = Vector2(0, 120)
 
 [node name="Stern" parent="SternSlot" instance=ExtResource("3_701t0")]
+
+[node name="Obstacles" type="Node2D" parent="."]
+
+[node name="Puddles" type="Node2D" parent="Obstacles"]
+
+[node name="Leaks" type="Node2D" parent="Obstacles"]

--- a/Scenes/boat_end.gd
+++ b/Scenes/boat_end.gd
@@ -22,3 +22,6 @@ func clear_cargo():
 	for cur_cargo in $CargoSlot.get_children():
 		$CargoSlot.remove_child(cur_cargo)
 	cargo = null
+
+func is_point_in_play_space(point: Vector2):
+	return Geometry2D.is_point_in_polygon(point-$PlaySpace/CollisionPolygon2D.global_position, $PlaySpace/CollisionPolygon2D.polygon)

--- a/Scenes/bow.tscn
+++ b/Scenes/bow.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://c0wkpqqx3mqf0"]
+[gd_scene load_steps=4 format=3 uid="uid://bg0meusunoosr"]
 
 [ext_resource type="Script" path="res://Scenes/boat_end.gd" id="1_6fuim"]
 [ext_resource type="Texture2D" uid="uid://bg62n7s5j2exq" path="res://Art/ShipTiles/ShipBow.png" id="1_45f1j"]
@@ -20,3 +20,8 @@ polygon = PackedVector2Array(-120, 60, -120, 13, -77, -25, -27, -49, 28, -49, 77
 [node name="CargoSlot" type="Node2D" parent="."]
 
 [node name="CrewMember" parent="CargoSlot" instance=ExtResource("2_0nha6")]
+
+[node name="PlaySpace" type="Area2D" parent="."]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="PlaySpace"]
+polygon = PackedVector2Array(-105, 60, -105, 11, 105, 11, 105, 60)

--- a/Scenes/crew_member.gd
+++ b/Scenes/crew_member.gd
@@ -57,8 +57,8 @@ func set_assignment(new_assignment: Node2D):
 		$AnimationPlayer.play("alert")
 	else:
 		if new_assignment is Task:
-			if new_assignment is Puddle:
-				new_assignment.died.connect(_on_assigned_puddle_died)
+			if new_assignment is Puddle or new_assignment is Leak:
+				new_assignment.died.connect(_on_assignment_died)
 			if new_assignment.set_assignee(self):
 				$InteractableRange/CollisionShape2D.set_deferred("disabled", false)
 			else:
@@ -123,9 +123,22 @@ func _bail_puddle() -> void:
 	if current_assignment is Puddle:
 		current_assignment.decrease_stage()
 		
-func _on_assigned_puddle_died():
-	stop_bailing()
+func _on_assignment_died():
+	if current_assignment is Puddle:
+		stop_bailing()
+	elif current_assignment is Leak:
+		set_assignment(null)
+	
+func start_patching():
+	if current_assignment is Leak:
+		$LeakPatchTimer.start()
 
 func _on_assignment_started() -> void:
 	if current_assignment is Puddle:
 		start_bailing()
+	elif current_assignment is Leak:
+		start_patching()
+
+func _on_leak_patch_timer_timeout() -> void:
+	if current_assignment is Leak:
+		current_assignment.patch()

--- a/Scenes/crew_member.tscn
+++ b/Scenes/crew_member.tscn
@@ -596,5 +596,10 @@ libraries = {
 }
 autoplay = "idle_down"
 
+[node name="LeakPatchTimer" type="Timer" parent="."]
+wait_time = 3.0
+one_shot = true
+
 [connection signal="assignment_started" from="." to="." method="_on_assignment_started"]
 [connection signal="body_entered" from="InteractableRange" to="." method="_on_interactable_range_body_entered"]
+[connection signal="timeout" from="LeakPatchTimer" to="." method="_on_leak_patch_timer_timeout"]

--- a/Scenes/deck.gd
+++ b/Scenes/deck.gd
@@ -51,8 +51,10 @@ func spawn_leak():
 		new_leak.scale.x *= -1
 	Globals.boat.add_obstacle(new_leak)
 
-func spawn_puddle(spawn_point: Vector2):
+func spawn_puddle(spawn_point: Vector2) -> Puddle:
 	var new_puddle = Globals.generate_task(Globals.Task_type.PUDDLE)
 	Globals.boat.add_obstacle(new_puddle)
-	new_puddle.global_position = spawn_point
-	return new_puddle
+	return new_puddle.spawn(spawn_point)
+
+func is_point_in_play_space(point: Vector2):
+	return Geometry2D.is_point_in_polygon(point-$PlayArea/CollisionPolygon2D.global_position, $PlayArea/CollisionPolygon2D.polygon)

--- a/Scenes/deck.gd
+++ b/Scenes/deck.gd
@@ -3,9 +3,11 @@ extends StaticBody2D
 class_name Deck
 
 @export var tasks: Array[Globals.Task_type]
+var spawn_boundary: Rect2
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	spawn_boundary = $SpawnArea/CollisionShape2D.shape.get_rect()
 	_set_up_tasks()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -41,3 +43,16 @@ func clear_deck():
 			if task is Task:
 				task.set_worker(null)
 			task.free()
+
+func spawn_leak():
+	var new_leak = Globals.generate_task(Globals.Task_type.LEAK)
+	new_leak.global_position = Vector2(randi_range(spawn_boundary.position.x, spawn_boundary.position.x + spawn_boundary.size.x), randi_range(spawn_boundary.position.y, spawn_boundary.position.y + spawn_boundary.size.y))
+	if new_leak.global_position.x > (spawn_boundary.position.x + spawn_boundary.size.x/2):
+		new_leak.scale.x *= -1
+	Globals.boat.add_obstacle(new_leak)
+
+func spawn_puddle(spawn_point: Vector2):
+	var new_puddle = Globals.generate_task(Globals.Task_type.PUDDLE)
+	Globals.boat.add_obstacle(new_puddle)
+	new_puddle.global_position = spawn_point
+	return new_puddle

--- a/Scenes/deck.tscn
+++ b/Scenes/deck.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=3 uid="uid://ccika7v5l27ew"]
+[gd_scene load_steps=7 format=3 uid="uid://ccika7v5l27ew"]
 
 [ext_resource type="Texture2D" uid="uid://dl2iyrtq3rdcy" path="res://Art/ShipTiles/ShipMiddle.png" id="1_146gp"]
 [ext_resource type="Script" path="res://Scenes/deck.gd" id="1_u6t8r"]
@@ -8,7 +8,10 @@
 size = Vector2(14, 120)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_tyg2r"]
-size = Vector2(15, 120)
+size = Vector2(14.5, 120)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_cgofq"]
+size = Vector2(210, 120)
 
 [node name="Deck" type="StaticBody2D"]
 collision_layer = 8
@@ -19,15 +22,22 @@ tasks = Array[int]([0, 0, 0, 0])
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_146gp")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="LeftWall" type="CollisionShape2D" parent="."]
 z_index = 1
-position = Vector2(-113, 0)
+position = Vector2(-112, 0)
 shape = SubResource("RectangleShape2D_pi8fu")
 
-[node name="CollisionShape2D2" type="CollisionShape2D" parent="."]
+[node name="RightWall" type="CollisionShape2D" parent="."]
 z_index = 1
-position = Vector2(112.5, 0)
+position = Vector2(112.25, 0)
 shape = SubResource("RectangleShape2D_tyg2r")
+
+[node name="SpawnArea" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="SpawnArea"]
+shape = SubResource("RectangleShape2D_cgofq")
 
 [node name="Tasks" type="Node2D" parent="."]
 

--- a/Scenes/deck.tscn
+++ b/Scenes/deck.tscn
@@ -40,6 +40,7 @@ collision_mask = 0
 shape = SubResource("RectangleShape2D_cgofq")
 
 [node name="Tasks" type="Node2D" parent="."]
+z_index = 1
 
 [node name="TopLeftSlot" type="Node2D" parent="Tasks"]
 position = Vector2(-75, -40)

--- a/Scenes/deck.tscn
+++ b/Scenes/deck.tscn
@@ -39,6 +39,11 @@ collision_mask = 0
 [node name="CollisionShape2D" type="CollisionShape2D" parent="SpawnArea"]
 shape = SubResource("RectangleShape2D_cgofq")
 
+[node name="PlayArea" type="Area2D" parent="."]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="PlayArea"]
+polygon = PackedVector2Array(-105, -60, 105, -60, 105, 60, -105, 60)
+
 [node name="Tasks" type="Node2D" parent="."]
 z_index = 1
 

--- a/Scenes/leak.gd
+++ b/Scenes/leak.gd
@@ -49,21 +49,12 @@ func _start_puddle_timer():
 	$PuddleTimer.start()
 
 func _on_puddle_timer_timeout() -> void:
-	if not current_puddle or current_puddle.stage >= Puddle.Stage.LARGE:
-		_get_new_puddle()
+	if not current_puddle:
+		current_puddle = Globals.boat.spawn_puddle($PuddleSpawnPoint.global_position)
+		if current_puddle:
+			current_puddle.died.connect(_on_current_puddle_died)
 	else:
 		current_puddle.increase_stage()
 		
-func _get_new_puddle():
-	var puddles = get_tree().get_nodes_in_group("puddle")
-	if current_puddle:
-		puddles.erase(current_puddle)
-	
-	if puddles.is_empty():
-		current_puddle = Globals.boat.spawn_puddle($PuddleSpawnPoint.global_position)
-	else:
-		var closest_puddle = puddles.front()
-		for puddle in puddles:
-			if puddle.stage < Puddle.Stage.LARGE and $PuddleSpawnPoint.global_position.distance_to(puddle.global_position) < $PuddleSpawnPoint.global_position.distance_to(closest_puddle.global_position):
-				closest_puddle = puddle
-		current_puddle = closest_puddle
+func _on_current_puddle_died():
+	current_puddle = null

--- a/Scenes/leak.gd
+++ b/Scenes/leak.gd
@@ -49,8 +49,21 @@ func _start_puddle_timer():
 	$PuddleTimer.start()
 
 func _on_puddle_timer_timeout() -> void:
-	#if not current_puddle or current_puddle.stage >= Puddle.Stage.LARGE:
-	if not current_puddle:
-		current_puddle = Globals.boat.spawn_puddle($PuddleSpawnPoint.global_position)
+	if not current_puddle or current_puddle.stage >= Puddle.Stage.LARGE:
+		_get_new_puddle()
 	else:
 		current_puddle.increase_stage()
+		
+func _get_new_puddle():
+	var puddles = get_tree().get_nodes_in_group("puddle")
+	if current_puddle:
+		puddles.erase(current_puddle)
+	
+	if puddles.is_empty():
+		current_puddle = Globals.boat.spawn_puddle($PuddleSpawnPoint.global_position)
+	else:
+		var closest_puddle = puddles.front()
+		for puddle in puddles:
+			if puddle.stage < Puddle.Stage.LARGE and $PuddleSpawnPoint.global_position.distance_to(puddle.global_position) < $PuddleSpawnPoint.global_position.distance_to(closest_puddle.global_position):
+				closest_puddle = puddle
+		current_puddle = closest_puddle

--- a/Scenes/leak.gd
+++ b/Scenes/leak.gd
@@ -1,0 +1,19 @@
+extends Task
+
+var is_patched = false
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+func patch():
+	is_patched = true
+	$AnimationTree.set("parameters/conditions/is_patched", true)
+	set_worker(null)
+
+func _die():
+	queue_free()

--- a/Scenes/leak.tscn
+++ b/Scenes/leak.tscn
@@ -90,10 +90,8 @@ animations = [{
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6p2vv"]
 size = Vector2(32, 22)
 
-[sub_resource type="Animation" id="Animation_6p51l"]
-resource_name = "start"
-length = 1.60002
-step = 0.2
+[sub_resource type="Animation" id="Animation_udslj"]
+length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -104,7 +102,7 @@ tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [&"start"]
+"values": [&"end"]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
@@ -113,24 +111,10 @@ tracks/1/path = NodePath("AnimatedSprite2D:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
-"update": 1,
-"values": [0, 1, 2, 3, 4, 5, 6, 7]
-}
-tracks/2/type = "method"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath(".")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(1.6),
+"times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"values": [{
-"args": [],
-"method": &"_start_puddle_timer"
-}]
+"update": 1,
+"values": [8]
 }
 
 [sub_resource type="Animation" id="Animation_d11gk"]
@@ -161,33 +145,6 @@ tracks/1/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 1,
 "values": [0, 1]
-}
-
-[sub_resource type="Animation" id="Animation_udslj"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:animation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [&"end"]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("AnimatedSprite2D:frame")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [8]
 }
 
 [sub_resource type="Animation" id="Animation_ue7vv"]
@@ -230,6 +187,49 @@ tracks/2/keys = {
 "values": [{
 "args": [],
 "method": &"_die"
+}]
+}
+
+[sub_resource type="Animation" id="Animation_6p51l"]
+resource_name = "start"
+length = 1.60002
+step = 0.2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"start"]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [0, 1, 2, 3, 4, 5, 6, 7]
+}
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(1.6),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"_start_puddle_timer"
 }]
 }
 

--- a/Scenes/leak.tscn
+++ b/Scenes/leak.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=24 format=3 uid="uid://c4xec2ylsa6d7"]
+[gd_scene load_steps=26 format=3 uid="uid://c4xec2ylsa6d7"]
 
+[ext_resource type="Script" path="res://Scenes/leak.gd" id="1_4ykgf"]
 [ext_resource type="Texture2D" uid="uid://u8r6eec7wpgv" path="res://Art/Leak/LeakH.png" id="1_unkym"]
 [ext_resource type="Texture2D" uid="uid://djseaj8ncqp0d" path="res://Art/Leak/LeakL.png" id="2_5105n"]
 [ext_resource type="Texture2D" uid="uid://e5k5iq6yaver" path="res://Art/Leak/LeakG.png" id="3_fe2xs"]
@@ -84,6 +85,9 @@ animations = [{
 "name": &"start",
 "speed": 5.0
 }]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_6p2vv"]
+size = Vector2(32, 22)
 
 [sub_resource type="Animation" id="Animation_6p51l"]
 resource_name = "start"
@@ -199,6 +203,20 @@ tracks/1/keys = {
 "update": 1,
 "values": [0, 1, 2, 3, 4, 5, 6, 7]
 }
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(1.6),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"_die"
+}]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_y5cdd"]
 _data = {
@@ -241,12 +259,18 @@ states/start/node = SubResource("AnimationNodeAnimation_kfqgv")
 states/start/position = Vector2(346, 100)
 transitions = ["Start", "start", SubResource("AnimationNodeStateMachineTransition_fyktv"), "start", "active", SubResource("AnimationNodeStateMachineTransition_hdtsh"), "active", "end", SubResource("AnimationNodeStateMachineTransition_tw351"), "end", "End", SubResource("AnimationNodeStateMachineTransition_vbovt")]
 
-[node name="Leak" type="Node2D"]
+[node name="Leak" type="StaticBody2D"]
+script = ExtResource("1_4ykgf")
+interaction_radius = 12
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0, -5)
 sprite_frames = SubResource("SpriteFrames_kn724")
 animation = &"end"
 frame = 8
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_6p2vv")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Scenes/leak.tscn
+++ b/Scenes/leak.tscn
@@ -117,6 +117,20 @@ tracks/1/keys = {
 "update": 1,
 "values": [0, 1, 2, 3, 4, 5, 6, 7]
 }
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(1.6),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"_start_puddle_timer"
+}]
+}
 
 [sub_resource type="Animation" id="Animation_d11gk"]
 resource_name = "active"
@@ -260,16 +274,20 @@ states/start/position = Vector2(346, 100)
 transitions = ["Start", "start", SubResource("AnimationNodeStateMachineTransition_fyktv"), "start", "active", SubResource("AnimationNodeStateMachineTransition_hdtsh"), "active", "end", SubResource("AnimationNodeStateMachineTransition_tw351"), "end", "End", SubResource("AnimationNodeStateMachineTransition_vbovt")]
 
 [node name="Leak" type="StaticBody2D"]
+z_index = 1
+collision_layer = 4
+collision_mask = 0
 script = ExtResource("1_4ykgf")
-interaction_radius = 12
+interaction_radius = 8
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-position = Vector2(0, -5)
+position = Vector2(16, -5)
 sprite_frames = SubResource("SpriteFrames_kn724")
 animation = &"end"
 frame = 8
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(16, 0)
 shape = SubResource("RectangleShape2D_6p2vv")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -283,3 +301,11 @@ tree_root = SubResource("AnimationNodeStateMachine_thc46")
 advance_expression_base_node = NodePath("../AnimationPlayer")
 anim_player = NodePath("../AnimationPlayer")
 parameters/conditions/is_patched = false
+
+[node name="PuddleTimer" type="Timer" parent="."]
+wait_time = 3.0
+
+[node name="PuddleSpawnPoint" type="Marker2D" parent="."]
+position = Vector2(32, 11)
+
+[connection signal="timeout" from="PuddleTimer" to="." method="_on_puddle_timer_timeout"]

--- a/Scenes/leak.tscn
+++ b/Scenes/leak.tscn
@@ -1,0 +1,261 @@
+[gd_scene load_steps=24 format=3 uid="uid://c4xec2ylsa6d7"]
+
+[ext_resource type="Texture2D" uid="uid://u8r6eec7wpgv" path="res://Art/Leak/LeakH.png" id="1_unkym"]
+[ext_resource type="Texture2D" uid="uid://djseaj8ncqp0d" path="res://Art/Leak/LeakL.png" id="2_5105n"]
+[ext_resource type="Texture2D" uid="uid://e5k5iq6yaver" path="res://Art/Leak/LeakG.png" id="3_fe2xs"]
+[ext_resource type="Texture2D" uid="uid://cghrfhbx6j0nv" path="res://Art/Leak/LeakF.png" id="4_ae6kl"]
+[ext_resource type="Texture2D" uid="uid://bkccbd8ak0tcm" path="res://Art/Leak/LeakE.png" id="5_df2nu"]
+[ext_resource type="Texture2D" uid="uid://b2favd7wgeyi2" path="res://Art/Leak/LeakD.png" id="6_8b1nt"]
+[ext_resource type="Texture2D" uid="uid://bhjgutwp72jnh" path="res://Art/Leak/LeakC.png" id="7_ut3nk"]
+[ext_resource type="Texture2D" uid="uid://cbfyvldqkv6xf" path="res://Art/Leak/LeakB.png" id="8_4dheh"]
+[ext_resource type="Texture2D" uid="uid://bcw2nn1y7uuup" path="res://Art/Leak/LeakA.png" id="9_j3e5d"]
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_kn724"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": ExtResource("2_5105n")
+}, {
+"duration": 1.0,
+"texture": ExtResource("1_unkym")
+}],
+"loop": true,
+"name": &"active",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": ExtResource("1_unkym")
+}, {
+"duration": 1.0,
+"texture": ExtResource("3_fe2xs")
+}, {
+"duration": 1.0,
+"texture": ExtResource("4_ae6kl")
+}, {
+"duration": 1.0,
+"texture": ExtResource("5_df2nu")
+}, {
+"duration": 1.0,
+"texture": ExtResource("6_8b1nt")
+}, {
+"duration": 1.0,
+"texture": ExtResource("7_ut3nk")
+}, {
+"duration": 1.0,
+"texture": ExtResource("8_4dheh")
+}, {
+"duration": 1.0,
+"texture": ExtResource("9_j3e5d")
+}, {
+"duration": 1.0,
+"texture": null
+}],
+"loop": false,
+"name": &"end",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": ExtResource("9_j3e5d")
+}, {
+"duration": 1.0,
+"texture": ExtResource("8_4dheh")
+}, {
+"duration": 1.0,
+"texture": ExtResource("7_ut3nk")
+}, {
+"duration": 1.0,
+"texture": ExtResource("6_8b1nt")
+}, {
+"duration": 1.0,
+"texture": ExtResource("5_df2nu")
+}, {
+"duration": 1.0,
+"texture": ExtResource("4_ae6kl")
+}, {
+"duration": 1.0,
+"texture": ExtResource("3_fe2xs")
+}, {
+"duration": 1.0,
+"texture": ExtResource("1_unkym")
+}],
+"loop": false,
+"name": &"start",
+"speed": 5.0
+}]
+
+[sub_resource type="Animation" id="Animation_6p51l"]
+resource_name = "start"
+length = 1.60002
+step = 0.2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"start"]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [0, 1, 2, 3, 4, 5, 6, 7]
+}
+
+[sub_resource type="Animation" id="Animation_d11gk"]
+resource_name = "active"
+length = 0.40002
+loop_mode = 1
+step = 0.2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"active"]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [0, 1]
+}
+
+[sub_resource type="Animation" id="Animation_udslj"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"end"]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [8]
+}
+
+[sub_resource type="Animation" id="Animation_ue7vv"]
+resource_name = "end"
+length = 1.60002
+step = 0.2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"end"]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [0, 1, 2, 3, 4, 5, 6, 7]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_y5cdd"]
+_data = {
+"RESET": SubResource("Animation_udslj"),
+"active": SubResource("Animation_d11gk"),
+"end": SubResource("Animation_ue7vv"),
+"start": SubResource("Animation_6p51l")
+}
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gm21h"]
+animation = &"active"
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_e7l26"]
+animation = &"end"
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kfqgv"]
+animation = &"start"
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_fyktv"]
+advance_mode = 2
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_hdtsh"]
+switch_mode = 2
+advance_mode = 2
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_tw351"]
+advance_mode = 2
+advance_condition = &"is_patched"
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_vbovt"]
+switch_mode = 2
+advance_mode = 2
+
+[sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_thc46"]
+states/active/node = SubResource("AnimationNodeAnimation_gm21h")
+states/active/position = Vector2(503, 103)
+states/end/node = SubResource("AnimationNodeAnimation_e7l26")
+states/end/position = Vector2(673, 103)
+states/start/node = SubResource("AnimationNodeAnimation_kfqgv")
+states/start/position = Vector2(346, 100)
+transitions = ["Start", "start", SubResource("AnimationNodeStateMachineTransition_fyktv"), "start", "active", SubResource("AnimationNodeStateMachineTransition_hdtsh"), "active", "end", SubResource("AnimationNodeStateMachineTransition_tw351"), "end", "End", SubResource("AnimationNodeStateMachineTransition_vbovt")]
+
+[node name="Leak" type="Node2D"]
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+sprite_frames = SubResource("SpriteFrames_kn724")
+animation = &"end"
+frame = 8
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_y5cdd")
+}
+autoplay = "active"
+
+[node name="AnimationTree" type="AnimationTree" parent="."]
+tree_root = SubResource("AnimationNodeStateMachine_thc46")
+advance_expression_base_node = NodePath("../AnimationPlayer")
+anim_player = NodePath("../AnimationPlayer")
+parameters/conditions/is_patched = false

--- a/Scenes/leak.tscn
+++ b/Scenes/leak.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=26 format=3 uid="uid://c4xec2ylsa6d7"]
+[gd_scene load_steps=27 format=3 uid="uid://c4xec2ylsa6d7"]
 
 [ext_resource type="Script" path="res://Scenes/leak.gd" id="1_4ykgf"]
 [ext_resource type="Texture2D" uid="uid://u8r6eec7wpgv" path="res://Art/Leak/LeakH.png" id="1_unkym"]
+[ext_resource type="Material" uid="uid://cf3tuv5aidq14" path="res://Materials/highlight_material.tres" id="2_7wtkj"]
 [ext_resource type="Texture2D" uid="uid://djseaj8ncqp0d" path="res://Art/Leak/LeakL.png" id="2_5105n"]
 [ext_resource type="Texture2D" uid="uid://e5k5iq6yaver" path="res://Art/Leak/LeakG.png" id="3_fe2xs"]
 [ext_resource type="Texture2D" uid="uid://cghrfhbx6j0nv" path="res://Art/Leak/LeakF.png" id="4_ae6kl"]
@@ -281,6 +282,7 @@ script = ExtResource("1_4ykgf")
 interaction_radius = 8
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+material = ExtResource("2_7wtkj")
 position = Vector2(16, -5)
 sprite_frames = SubResource("SpriteFrames_kn724")
 animation = &"end"

--- a/Scenes/playground.gd
+++ b/Scenes/playground.gd
@@ -15,3 +15,4 @@ func _boat_speed_updated():
 func _on_boat_ready() -> void:
 	Globals.set_boat($Boat)
 	Globals.boat.spawn_leak()
+	Globals.boat.spawn_leak()

--- a/Scenes/playground.gd
+++ b/Scenes/playground.gd
@@ -14,3 +14,4 @@ func _boat_speed_updated():
 
 func _on_boat_ready() -> void:
 	Globals.set_boat($Boat)
+	Globals.boat.spawn_leak()

--- a/Scenes/playground.tscn
+++ b/Scenes/playground.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://je3j0pd8ickv" path="res://Scenes/splish.tscn" id="1_vcfar"]
 [ext_resource type="Script" path="res://Scenes/game_camera.gd" id="2_gusxx"]
 [ext_resource type="PackedScene" uid="uid://ptto4146phwg" path="res://Scenes/boat.tscn" id="2_twya3"]
-[ext_resource type="PackedScene" uid="uid://b3860lvbbt8q5" path="res://Scenes/puddle.tscn" id="7_qljs6"]
+[ext_resource type="PackedScene" uid="uid://c4xec2ylsa6d7" path="res://Scenes/leak.tscn" id="7_vcuby"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_qe181"]
 line_spacing = 1.0
@@ -81,13 +81,7 @@ position = Vector2(722, 714)
 
 [node name="Obstacles" type="Node" parent="."]
 
-[node name="Puddle" parent="Obstacles" instance=ExtResource("7_qljs6")]
-position = Vector2(273, 270)
-
-[node name="Puddle2" parent="Obstacles" instance=ExtResource("7_qljs6")]
-position = Vector2(384, 272)
-
-[node name="Puddle3" parent="Obstacles" instance=ExtResource("7_qljs6")]
-position = Vector2(273, 300)
+[node name="Leak" parent="Obstacles" instance=ExtResource("7_vcuby")]
+position = Vector2(231, 257)
 
 [connection signal="ready" from="Boat" to="." method="_on_boat_ready"]

--- a/Scenes/playground.tscn
+++ b/Scenes/playground.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://byk8jyx3r65e2"]
+[gd_scene load_steps=8 format=3 uid="uid://byk8jyx3r65e2"]
 
 [ext_resource type="Script" path="res://Scenes/playground.gd" id="1_bs7od"]
 [ext_resource type="Texture2D" uid="uid://v8dy2ved6iwm" path="res://Art/BG/WaterBackground.png" id="1_e04j1"]
@@ -6,7 +6,6 @@
 [ext_resource type="PackedScene" uid="uid://je3j0pd8ickv" path="res://Scenes/splish.tscn" id="1_vcfar"]
 [ext_resource type="Script" path="res://Scenes/game_camera.gd" id="2_gusxx"]
 [ext_resource type="PackedScene" uid="uid://ptto4146phwg" path="res://Scenes/boat.tscn" id="2_twya3"]
-[ext_resource type="PackedScene" uid="uid://c4xec2ylsa6d7" path="res://Scenes/leak.tscn" id="7_vcuby"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_qe181"]
 line_spacing = 1.0
@@ -76,12 +75,6 @@ position = Vector2(320, 180)
 script = ExtResource("2_gusxx")
 focus_target = NodePath("../Splish")
 
-[node name="LocationTest" type="Marker2D" parent="."]
-position = Vector2(722, 714)
-
 [node name="Obstacles" type="Node" parent="."]
-
-[node name="Leak" parent="Obstacles" instance=ExtResource("7_vcuby")]
-position = Vector2(231, 257)
 
 [connection signal="ready" from="Boat" to="." method="_on_boat_ready"]

--- a/Scenes/puddle.gd
+++ b/Scenes/puddle.gd
@@ -28,7 +28,7 @@ var stage = Stage.SMALL
 var affecting_speed = false
 
 # Store neighbor puddle states here
-		#[top]
+	   #[top]
 #[left] [self] [right]
 	  #[bottom]
 var neighbor_puddles = {
@@ -45,7 +45,7 @@ func _ready() -> void:
 	else:
 		_update_stage()
 	
-	_set_neighbor_spawn_points()
+	_update_neighbor_spawn_points()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
@@ -120,14 +120,14 @@ func spawn(spawn_point: Vector2) -> Puddle:
 		print_debug("Not spawning ", self, " at ", spawn_point, ". Already occupied by ", spawn_point_occupant)
 		queue_free()
 	else:
-		_set_neighbor_spawn_points()
+		_update_neighbor_spawn_points()
 		spawn_point_occupant = self
 	
 	_update_neighbor_puddles()
 	
 	return spawn_point_occupant
 	
-func _set_neighbor_spawn_points():
+func _update_neighbor_spawn_points():
 	neighbor_puddles["top"]["spawn_point"] = $NeighborSpawnPoints/Top.global_position
 	neighbor_puddles["bottom"]["spawn_point"] = $NeighborSpawnPoints/Bottom.global_position
 	neighbor_puddles["right"]["spawn_point"] = $NeighborSpawnPoints/Right.global_position
@@ -144,9 +144,6 @@ func _check_spawn_space_occupied(spawning_puddle: Puddle) -> Puddle:
 			break
 	
 	return null
-	
-func is_point_in_self(point: Vector2):
-	return Geometry2D.is_point_in_polygon(point-$SelfSpace/CollisionPolygon2D.global_position, $SelfSpace/CollisionPolygon2D.polygon)
 
 func _update_neighbor_puddles():
 	for neighbor in neighbor_puddles.values():

--- a/Scenes/puddle.gd
+++ b/Scenes/puddle.gd
@@ -12,7 +12,7 @@ enum Stage {
 
 const SPEED_CHANGE = -50
 
-var stage = Stage.LARGE
+var stage = Stage.SMALL
 
 var affecting_speed = false
 
@@ -42,7 +42,6 @@ func increase_stage():
 	if stage < Stage.LARGE:
 		stage += 1
 		_set_stage()
-	# TODO: Else, spread
 
 func decrease_stage():
 	if stage <= Stage.SMALL:

--- a/Scenes/puddle.tscn
+++ b/Scenes/puddle.tscn
@@ -50,3 +50,38 @@ autoplay = "small"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_8ratk")
+
+[node name="SelfSpace" type="Area2D" parent="."]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="SelfSpace"]
+polygon = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+
+[node name="NeighborSpawnPoints" type="Node2D" parent="."]
+
+[node name="Top" type="Marker2D" parent="NeighborSpawnPoints"]
+position = Vector2(0, -32)
+
+[node name="Polygon2D" type="Polygon2D" parent="NeighborSpawnPoints/Top"]
+color = Color(1, 1, 1, 0)
+polygon = PackedVector2Array(-16, 16, -16, -16, 16, -16, 16, 16)
+
+[node name="Bottom" type="Marker2D" parent="NeighborSpawnPoints"]
+position = Vector2(0, 32)
+
+[node name="Polygon2D" type="Polygon2D" parent="NeighborSpawnPoints/Bottom"]
+color = Color(1, 1, 1, 0)
+polygon = PackedVector2Array(-16, 16, -16, -16, 16, -16, 16, 16)
+
+[node name="Right" type="Marker2D" parent="NeighborSpawnPoints"]
+position = Vector2(32, 0)
+
+[node name="Polygon2D" type="Polygon2D" parent="NeighborSpawnPoints/Right"]
+color = Color(1, 1, 1, 0)
+polygon = PackedVector2Array(-16, 16, -16, -16, 16, -16, 16, 16)
+
+[node name="Left" type="Marker2D" parent="NeighborSpawnPoints"]
+position = Vector2(-32, 0)
+
+[node name="Polygon2D" type="Polygon2D" parent="NeighborSpawnPoints/Left"]
+color = Color(1, 1, 1, 0)
+polygon = PackedVector2Array(-16, 16, -16, -16, 16, -16, 16, 16)

--- a/Scenes/puddle.tscn
+++ b/Scenes/puddle.tscn
@@ -34,7 +34,7 @@ animations = [{
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_8ratk"]
-size = Vector2(24, 24)
+size = Vector2(32, 32)
 
 [node name="Puddle" type="StaticBody2D" groups=["puddle"]]
 collision_layer = 4
@@ -45,7 +45,7 @@ interaction_radius = 24
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 material = ExtResource("2_wa86k")
 sprite_frames = SubResource("SpriteFrames_2wk1l")
-animation = &"large"
+animation = &"small"
 autoplay = "small"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Scenes/stern.tscn
+++ b/Scenes/stern.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://rdtpfywwpj45"]
+[gd_scene load_steps=4 format=3 uid="uid://dmy5awjreptlw"]
 
 [ext_resource type="Script" path="res://Scenes/boat_end.gd" id="1_0cbxb"]
 [ext_resource type="Texture2D" uid="uid://ct0gilfhdq48q" path="res://Art/ShipTiles/ShipStern.png" id="1_kfflb"]
@@ -21,3 +21,8 @@ polygon = PackedVector2Array(-120, 60, -120, 13, -77, -25, -27, -49, 28, -49, 77
 [node name="CargoSlot" type="Node2D" parent="."]
 
 [node name="CrewMember" parent="CargoSlot" instance=ExtResource("3_nqwn3")]
+
+[node name="PlaySpace" type="Area2D" parent="."]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="PlaySpace"]
+polygon = PackedVector2Array(-105, -60, -105, -11, 105, -11, 105, -60)

--- a/Scripts/globals.gd
+++ b/Scripts/globals.gd
@@ -8,10 +8,14 @@ var boat: Boat
 
 enum Task_type {
 	ROWING,
+	LEAK,
+	PUDDLE,
 }
 
 var task_dict = {
 	Task_type.ROWING: load("res://Scenes/rowing_task.tscn"),
+	Task_type.LEAK: load("res://Scenes/leak.tscn"),
+	Task_type.PUDDLE: load("res://Scenes/puddle.tscn"),
 }
 
 # Called when the node enters the scene tree for the first time.

--- a/project.godot
+++ b/project.godot
@@ -89,6 +89,7 @@ location={
 2d_physics/layer_2="Crew"
 2d_physics/layer_3="Interactable"
 2d_physics/layer_4="Boundaries"
+2d_physics/layer_5="Puddles"
 
 [rendering]
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/ced6bd2d-c476-4dcd-a2ab-c235d84dbec5

https://github.com/user-attachments/assets/2d8364fd-1290-4b99-b38b-51404079dab2

LEARNED A TON. Not sure if it's the "right" way to do it, but it seems to work as expected and it looks great, IMO!

Basically, implemented what I'm calling "orthogonal overflow logic", where each puddle, when it goes above capacity, splits the overflow into 4 and adds that to each orthogonal "space".

IN ADDITION, I had to define what "open" and "space" meant. A "space" is a region the size of a puddle. A "space" being "open" is that puddle sized region not intersecting with any other puddle "space". If it intersects with any other puddle "space" that puddle becomes the respective orthogonal neighbor puddle that can be spread to.

The above results in a leak spawning a single puddle that fills up quickly then spreads orthogonally at the same total source rate from the leak, so as things spread, the total area the leak affects grows more and more slowly, kind of like how a constant leak would behave when spreading out to an increasingly large surface area in real life.

There are definitely situations where the puddle spreading disappears into the void (namely on walls), but I think the logic works really well for the purposes of the leak/puddle obstacles.

IN THEORY, this logic also supports taking on water due to a single massive water event, like a wave since any overflow should spread until it is used up. Untested, but we'll see if we even try to do that.

This was a really fun challenge that I probably could have done something much simpler for and it would have been fine, but I got a little obsessed with it.



