### PR TITLE
Use grid to spawn puddles and leaks

### DIFF
--- a/Scenes/boat.gd
+++ b/Scenes/boat.gd
@@ -81,9 +81,9 @@ func change_speed(change: int):
 		Globals.update_boat_speed(speed)
 
 func spawn_leak():
-	var spawn_point = $PlayGrid.global_position + Vector2(randi_range(0,200), randi_range(0,length))
+	var spawn_point = $PlayGrid.global_position + Vector2(randi_range(0,300), randi_range(0,length))
 	while not is_point_in_boat(spawn_point):
-		spawn_point = $PlayGrid.global_position + Vector2(randi_range(0,200), randi_range(0,length))
+		spawn_point = $PlayGrid.global_position + Vector2(randi_range(0,300), randi_range(0,length))
 	if not $PlayGrid.spawn_leak(spawn_point):
 		spawn_leak()
 

--- a/Scenes/boat.gd
+++ b/Scenes/boat.gd
@@ -81,12 +81,15 @@ func change_speed(change: int):
 		Globals.update_boat_speed(speed)
 
 func spawn_leak():
-	$DeckSlot.get_children().front().spawn_leak()
+	var spawn_point = $PlayGrid.global_position + Vector2(randi_range(0,200), randi_range(0,length))
+	while not is_point_in_boat(spawn_point):
+		spawn_point = $PlayGrid.global_position + Vector2(randi_range(0,200), randi_range(0,length))
+	if not $PlayGrid.spawn_leak(spawn_point):
+		spawn_leak()
 
 func spawn_puddle(spawn_point: Vector2):
 	if is_point_in_boat(spawn_point):
-		return $DeckSlot.get_children().front().spawn_puddle(spawn_point)
-	
+		return $PlayGrid.spawn_puddle(spawn_point)
 	return null
 	
 func add_obstacle(new_obstacle: Node2D):

--- a/Scenes/bow.tscn
+++ b/Scenes/bow.tscn
@@ -22,7 +22,7 @@ position = Vector2(0, 11)
 [node name="PlaySpace" type="Area2D" parent="."]
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="PlaySpace"]
-polygon = PackedVector2Array(-112, 62, -112, -2, -80, -2, -80, -34, 80, -34, 80, -2, 112, -2, 112, 62)
+polygon = PackedVector2Array(-112, 62, -112, -2, 112, -2, 112, 62)
 
 [node name="PlayGrid" parent="." instance=ExtResource("3_obwje")]
 position = Vector2(-112, -34)

--- a/Scenes/cargo.tscn
+++ b/Scenes/cargo.tscn
@@ -7,7 +7,7 @@
 [sub_resource type="CircleShape2D" id="CircleShape2D_7kyn7"]
 radius = 33.0
 
-[node name="Cargo" type="StaticBody2D" groups=["cargo"]]
+[node name="Cargo" type="StaticBody2D" groups=["cargo", "impassable"]]
 z_index = 1
 collision_layer = 32
 collision_mask = 0

--- a/Scenes/deck.gd
+++ b/Scenes/deck.gd
@@ -44,21 +44,6 @@ func clear_deck():
 	for slot in task_slots:
 		slot.clear()
 
-func spawn_leak():
-	var new_leak = Globals.generate_task(Globals.Task_type.LEAK)
-	Globals.boat.add_obstacle(new_leak)
-	var spawned_leak = new_leak.spawn(Vector2(randi_range(spawn_boundary.position.x + global_position.x, spawn_boundary.position.x + spawn_boundary.size.x + global_position.x), randi_range(spawn_boundary.position.y + global_position.y, spawn_boundary.position.y + spawn_boundary.size.y + global_position.y)))
-	if spawned_leak == new_leak:
-		if new_leak.global_position.x > (spawn_boundary.position.x + global_position.x + spawn_boundary.size.x/2):
-			new_leak.scale.x *= -1
-	else:
-		spawn_leak()
-
-func spawn_puddle(spawn_point: Vector2) -> Puddle:
-	var new_puddle = Globals.generate_task(Globals.Task_type.PUDDLE)
-	Globals.boat.add_obstacle(new_puddle)
-	return new_puddle.spawn(spawn_point)
-
 func is_point_in_play_space(point: Vector2):
 	return Geometry2D.is_point_in_polygon(point-$PlayArea/CollisionPolygon2D.global_position, $PlayArea/CollisionPolygon2D.polygon)
 

--- a/Scenes/leak.gd
+++ b/Scenes/leak.gd
@@ -79,3 +79,9 @@ func set_highlight(is_enable: bool):
 		
 func _start_leak():
 	$SFXManager.play("Active")
+
+func spawn(spawn_point: Vector2):
+	var spawn_occupant = _spawn("impassable", spawn_point)
+	if spawn_occupant == self:
+		spawn_occupant = _spawn("leak", spawn_point)
+	return spawn_occupant

--- a/Scenes/leak.tscn
+++ b/Scenes/leak.tscn
@@ -90,7 +90,7 @@ animations = [{
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6p2vv"]
-size = Vector2(32, 22)
+size = Vector2(32, 32)
 
 [sub_resource type="Animation" id="Animation_udslj"]
 length = 0.001
@@ -288,13 +288,12 @@ interaction_radius = 8
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 material = ExtResource("2_7wtkj")
-position = Vector2(16, -5)
+position = Vector2(14, -10)
 sprite_frames = SubResource("SpriteFrames_kn724")
 animation = &"end"
 frame = 8
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(16, 0)
 shape = SubResource("RectangleShape2D_6p2vv")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -313,14 +312,16 @@ parameters/conditions/is_patched = false
 wait_time = 3.0
 
 [node name="PuddleSpawnPoint" type="Marker2D" parent="."]
-position = Vector2(32, 11)
+position = Vector2(32, 0)
 
 [node name="SelfSpace" type="Area2D" parent="."]
+position = Vector2(-16, 5)
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="SelfSpace"]
-polygon = PackedVector2Array(0, -11, 32, -11, 32, 11, 0, 11)
+polygon = PackedVector2Array(0, -21, 32, -21, 32, 11, 0, 11)
 
 [node name="SFXManager" parent="." instance=ExtResource("12_klpg4")]
+position = Vector2(0, -5)
 
 [node name="Active" type="AudioStreamPlayer2D" parent="SFXManager"]
 stream = ExtResource("13_b7rxi")

--- a/Scenes/puddle.gd
+++ b/Scenes/puddle.gd
@@ -136,7 +136,13 @@ func spawn(spawn_point: Vector2):
 		_update_neighbor_spawn_points()
 		var cargo_check_occupant = _check_spawn_space_occupied("cargo")
 		if cargo_check_occupant is Cargo:
-			cargo_check_occupant.add_threat(self)
+			if global_position == cargo_check_occupant.global_position:
+				stage = Stage.LARGE
+				spread(SPREAD_AMOUNT, self)
+				queue_free()
+				return null
+			else:
+				cargo_check_occupant.add_threat(self)
 		
 	_update_neighbor_puddles()
 	

--- a/Scenes/rowing_task_left.tscn
+++ b/Scenes/rowing_task_left.tscn
@@ -203,7 +203,7 @@ _data = {
 "stop": SubResource("Animation_66pub")
 }
 
-[node name="RowingTask" type="StaticBody2D" groups=["rowing_task"]]
+[node name="RowingTask" type="StaticBody2D" groups=["impassable", "rowing_task"]]
 z_index = 1
 scale = Vector2(1, -1)
 collision_layer = 12

--- a/Scenes/rowing_task_right.tscn
+++ b/Scenes/rowing_task_right.tscn
@@ -203,7 +203,7 @@ _data = {
 "stop": SubResource("Animation_66pub")
 }
 
-[node name="RowingTaskRight" type="StaticBody2D" groups=["rowing_task"]]
+[node name="RowingTaskRight" type="StaticBody2D" groups=["impassable", "rowing_task"]]
 z_index = 1
 scale = Vector2(1, -1)
 collision_layer = 12

--- a/Scenes/stern.tscn
+++ b/Scenes/stern.tscn
@@ -21,7 +21,7 @@ polygon = PackedVector2Array(-127, 61.9997, -127, -0.000321968, -84.9999, -38.00
 [node name="PlaySpace" type="Area2D" parent="."]
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="PlaySpace"]
-polygon = PackedVector2Array(-112, -62, -112, 2, -80, 2, -80, 34, 80, 34, 80, 2, 112, 2, 112, -62)
+polygon = PackedVector2Array(-112, -62, -112, 2, 112, 2, 112, -62)
 
 [node name="PlayGrid" parent="." instance=ExtResource("4_sgco4")]
 position = Vector2(-112, -62)

--- a/Scripts/obstacle.gd
+++ b/Scripts/obstacle.gd
@@ -3,7 +3,7 @@ extends Task
 class_name Obstacle
 
 func spawn(spawn_point: Vector2):
-	return _spawn("rowing_task", spawn_point)
+	return _spawn("impassable", spawn_point)
 
 func _spawn(group: String, spawn_point: Vector2):
 	global_position = spawn_point

--- a/Scripts/play_grid.gd
+++ b/Scripts/play_grid.gd
@@ -23,3 +23,24 @@ func get_cargo_slots() -> Array[CargoSlot]:
 		if child is CargoSlot:
 			cargo_slots.append(child)
 	return cargo_slots
+
+func spawn_leak(spawn_point: Vector2):
+	var new_leak = Globals.generate_task(Globals.Task_type.LEAK)
+	if new_leak is Leak:
+		Globals.boat.add_obstacle(new_leak)
+		var spawned_leak = new_leak.spawn(center_point_in_cell(spawn_point))
+		if spawned_leak == new_leak:
+			if new_leak.global_position.x > Globals.boat.global_position.x:
+				new_leak.scale.x *= -1
+			return true
+		else:
+			return false
+
+func spawn_puddle(spawn_point: Vector2) -> Puddle:
+	var new_puddle = Globals.generate_task(Globals.Task_type.PUDDLE)
+	Globals.boat.add_obstacle(new_puddle)
+	return new_puddle.spawn(center_point_in_cell(spawn_point))
+
+# Point must be global, not local
+func center_point_in_cell(point: Vector2):
+	return to_global(map_to_local(local_to_map(to_local(point))))

--- a/project.godot
+++ b/project.godot
@@ -38,6 +38,7 @@ leak=""
 rowing_task=""
 cargo=""
 destructable=""
+impassable=""
 
 [gui]
 


### PR DESCRIPTION
Shifted leak sprite to look better.

Leak targeting area made 32x32 to fill the tile, even though the sprite goes to neighboring cell to spawn puddle

Later ( #165 ) to add in handling of cells only holding so many of each type of obstacle and such for easier targeting

Video of a reasonable scenario:


https://github.com/user-attachments/assets/0c983de0-cdc2-41ef-8117-f2d43938e356





Screenshot showing the grid works 😄 
![image](https://github.com/user-attachments/assets/4bbea9ba-ff8e-4f98-a889-f819f5cd72a2)

