### PR TITLE
Set audio playback for web to sample

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -17,10 +17,6 @@ boot_splash/image="res://SplashySplashScreen.png"
 boot_splash/fullsize=false
 config/icon="res://Art/Splish/Idle/SplishIdle.png"
 
-[audio]
-
-general/default_playback_type.web=0
-
 [autoload]
 
 Globals="*res://SCRIPTS/globals.gd"


### PR DESCRIPTION
In theory, setting the audio playback mode for web to "sample" should help with this.

Audio crackle/pop occurrence:

- Loaded game on MOBILE-WEB 10 times with web audio set to "stream": 0
- Loaded game on MOBILE-WEB 10 times with web audio set to "sample": 0
- Loaded game on DESKTOP-WEB 5 times with web audio set to "sample": 0

Based on the above, it does not appear to hurt to set it to "sample", so we'll err on the side of setting it to sample to prevent this being seen again.